### PR TITLE
Fix check about number of components

### DIFF
--- a/slapshot-core/src/main/kotlin/se/gustavkarlsson/slapshot/core/testers/ImageTester.kt
+++ b/slapshot-core/src/main/kotlin/se/gustavkarlsson/slapshot/core/testers/ImageTester.kt
@@ -59,7 +59,7 @@ public data class ImageTester(
 
             actual.colorModel.numComponents != (expected.colorModel.numComponents) -> {
                 "Images have different numbers of components. Alpha missing?" +
-                        " Expected: ${expected.colorModel.numComponents}, actual: ${actual.colorModel.numComponents}"
+                    " Expected: ${expected.colorModel.numComponents}, actual: ${actual.colorModel.numComponents}"
             }
 
             !actual.colorModel.componentSize.all { it == 8 } -> {

--- a/slapshot-core/src/main/kotlin/se/gustavkarlsson/slapshot/core/testers/ImageTester.kt
+++ b/slapshot-core/src/main/kotlin/se/gustavkarlsson/slapshot/core/testers/ImageTester.kt
@@ -57,9 +57,9 @@ public data class ImageTester(
                 "Images have different transparency type"
             }
 
-            !actual.colorModel.componentSize.contentEquals(expected.colorModel.componentSize) -> {
-                "Images have different component sizes. Alpha missing?" +
-                    " Expected: ${expected.colorModel.componentSize}, actual: ${actual.colorModel.componentSize}"
+            actual.colorModel.numComponents != (expected.colorModel.numComponents) -> {
+                "Images have different numbers of components. Alpha missing?" +
+                        " Expected: ${expected.colorModel.numComponents}, actual: ${actual.colorModel.numComponents}"
             }
 
             !actual.colorModel.componentSize.all { it == 8 } -> {


### PR DESCRIPTION
The check was making sure the bit depth was the same when it should have checked that the number of components is the same (e.g. RGB vs RGBA, 3 vs 4)

See snippet or [example](https://pl.kotl.in/WXT2W62GV)

```kotlin
fun main() {
    val expected = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
    val actual = BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB)

    if (actual.colorModel.numComponents != (expected.colorModel.numComponents)) {
        println(
            "Images have different numbers of components. Alpha missing?" +
                    " Expected: ${expected.colorModel.numComponents}, actual: ${actual.colorModel.numComponents}"
        )
    }
}
```